### PR TITLE
Allow specification of the permissions for decrypted files.

### DIFF
--- a/capistrano-ejson.gemspec
+++ b/capistrano-ejson.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "capistrano-ejson"
-  spec.version       = "1.0.0"
+  spec.version       = "1.0.1"
   spec.authors       = ["Bouke van der Bijl"]
   spec.email         = ["bouke@shopify.com"]
   spec.description = spec.summary = %q{Automatic EJSON decryption for Capistrano}

--- a/lib/capistrano/tasks/ejson.cap
+++ b/lib/capistrano/tasks/ejson.cap
@@ -5,6 +5,7 @@ namespace :ejson do
 
   task :decrypt do
     ejson_file = fetch(:ejson_file)
+    ejson_file_mode = fetch(:ejson_file_mode)
     ejson_output_file = fetch(:ejson_output_file)
     ejson_deploy_mode = fetch(:ejson_deploy_mode)
 
@@ -14,7 +15,7 @@ namespace :ejson do
         if wait_thr.value == 0
           contents = stdout.read
           on release_roles(:all) do
-            upload! StringIO.new(contents), File.join(release_path, ejson_output_file)
+            upload! StringIO.new(contents), File.join(release_path, ejson_output_file), mode: ejson_file_mode
           end
         else
           raise "Failed to decrypt file #{stderr.read}"
@@ -37,6 +38,7 @@ end
 namespace :load do
   task :defaults do
     set :ejson_file, 'config/secrets.ejson'
+    set :ejson_file_mode, nil
     set :ejson_output_file, 'config/secrets.json'
     set :ejson_deploy_mode, :local
   end


### PR DESCRIPTION
We would like to be able to manually specify the permissions of the uploaded secrets file so that sudo commands are unnecessary in our deploy scripts for [Shopify/imagery3](//github.com/Shopify/imagery3). We kept the default mode as `nil` so that behaviour should not change if someone upgraded their gems.

@bouk
cc: @Shopify/cloud 