### PR TITLE
Use Open3.capture3 as it implicly waits for the command to finish.

### DIFF
--- a/lib/capistrano/tasks/ejson.cap
+++ b/lib/capistrano/tasks/ejson.cap
@@ -11,7 +11,7 @@ namespace :ejson do
 
     case ejson_deploy_mode
     when :local
-      out, err, status = Open3.capture3("bundle exec ejson decrypt #{ejson_file}")
+      out, err, status = Open3.capture3('bundle', 'exec', 'ejson', 'decrypt', ejson_file)
       if status.exitstatus == 0
         on release_roles(:all) do
           upload! StringIO.new(out), File.join(release_path, ejson_output_file), mode: ejson_file_mode

--- a/lib/capistrano/tasks/ejson.cap
+++ b/lib/capistrano/tasks/ejson.cap
@@ -11,15 +11,13 @@ namespace :ejson do
 
     case ejson_deploy_mode
     when :local
-      Open3.popen3('bundle', 'exec', 'ejson', 'decrypt', ejson_file) do |stdin, stdout, stderr, wait_thr|
-        if wait_thr.value == 0
-          contents = stdout.read
-          on release_roles(:all) do
-            upload! StringIO.new(contents), File.join(release_path, ejson_output_file), mode: ejson_file_mode
-          end
-        else
-          raise "Failed to decrypt file #{stderr.read}"
+      out, err, status = Open3.capture3("bundle exec ejson decrypt #{ejson_file}")
+      if status.exitstatus == 0
+        on release_roles(:all) do
+          upload! StringIO.new(out), File.join(release_path, ejson_output_file), mode: ejson_file_mode
         end
+      else
+        raise "Failed to decrypt file #{err}"
       end
     when :remote
       on release_roles(:all) do


### PR DESCRIPTION
Open3.popen3 was having problem when deploying from my OSX 10.11.6
machine to a remote CentOS 6.7. The command would never finish in
`wait_thr.value`.

  **Environment**

-   ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
-   Capistrano Version: 3.6.1 (Rake Version: 11.2.2)
-  Darwin localhost 15.6.0 Darwin Kernel Version 15.6.0: Mon Jan 11 9 23:07:29 PST 2017; root:xnu-3248.60.11.2.1~1/RELEASE_X86_64 x86_64
-  Linux remotehost 2.6.32-696.1.1.el6.x86_64 #1 SMP Tue Apr 11 13 17:13:24 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux