### PR TITLE
Remove bundler as a development dependency

### DIFF
--- a/capistrano-ejson.gemspec
+++ b/capistrano-ejson.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano', '~> 3.1'
   spec.add_dependency 'ejson', '~> 1.0', '>= 1.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Needed to be able to successfully publish to Rubygems, where I'm currently experiencing this:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.7)
  Current Bundler version:
    bundler (2.0.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
Could not find gem 'bundler (~> 1.7)' in any of the relevant sources:
  the local ruby installation
```